### PR TITLE
Fixed code point decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 .PHONY: all build clean test
 
 build:
-	jbuilder build --dev @install
+	dune build @install
 
 all: build
 
 test:
-	jbuilder runtest --dev
+	dune runtest
 
 install:
-	jbuilder install
+	dune install
 
 uninstall:
-	jbuilder uninstall
+	dune uninstall
 
 clean:
 	rm -rf _build *.install

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name jsonaf)

--- a/jsonaf.opam
+++ b/jsonaf.opam
@@ -6,14 +6,14 @@ homepage: "https://github.com/inhabitedtype/jsonaf"
 bug-reports: "https://github.com/inhabitedtype/jsonaf/issues"
 dev-repo: "https://github.com/inhabitedtype/jsonaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 build-test: [
-  ["jbuilder" "runtest" "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {build & >= "1.0+beta10"}
+  "dune" {build & >= "1.0"}
   "alcotest" {test}
   "angstrom" {>= "0.7.0"}
   "faraday"  {>= "0.5.0"}

--- a/lib/dune
+++ b/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name jsonaf)
+ (public_name jsonaf)
+ (libraries angstrom faraday result)
+ (flags :standard -safe-string))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,8 +1,0 @@
-(jbuild_version 1)
-
-(library
- ((name        jsonaf)
-  (public_name jsonaf)
-  (libraries
-    (angstrom faraday result))
-  (flags (:standard -safe-string))))

--- a/lib/json_string.ml
+++ b/lib/json_string.ml
@@ -78,6 +78,48 @@ module Parse = struct
     | 'A' .. 'F' -> Char.code c - 55
     | _          -> 255
 
+  (* Copied from Yojson *)
+  let utf8_of_code buf x =
+
+    (* Straight <= doesn't work with signed 31-bit ints *)
+    let maxbits n x = x lsr n = 0 in
+
+    if maxbits 7 x then
+      (* 7 *)
+      Buffer.add_char buf (Char.unsafe_chr x)
+    else if maxbits 11 x then begin
+      (* 5 + 6 *)
+      Buffer.add_char buf (Char.unsafe_chr (0b11000000 lor ((x lsr 6) land 0b00011111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor (x         land 0b00111111)))
+    end else if maxbits 16 x then begin
+      (* 4 + 6 + 6 *)
+      Buffer.add_char buf (Char.unsafe_chr (0b11100000 lor ((x lsr 12) land 0b00001111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr  6) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor (x          land 0b00111111)))
+    end else if maxbits 21 x then begin
+      (* 3 + 6 + 6 + 6 *)
+      Buffer.add_char buf (Char.unsafe_chr (0b11110000 lor ((x lsr 18) land 0b00000111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr 12) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr  6) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor (x          land 0b00111111)));
+    end else if maxbits 26 x then begin
+      (* 2 + 6 + 6 + 6 + 6 *)
+      Buffer.add_char buf (Char.unsafe_chr (0b11111000 lor ((x lsr 24) land 0b00000011)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr 18) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr 12) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr  6) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor (x          land 0b00111111)));
+    end else begin
+      assert (maxbits 31 x);
+      (* 1 + 6 + 6 + 6 + 6 + 6 *)
+      Buffer.add_char buf (Char.unsafe_chr (0b11111100 lor ((x lsr 30) land 0b00000001)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr 24) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr 18) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr 12) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((x lsr  6) land 0b00111111)));
+      Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor (x          land 0b00111111)));
+    end
+
   let utf_8 buf d = function
     | [c;b;a] ->
       let a = hex a and b = hex b and c = hex c and d = hex d in
@@ -88,9 +130,7 @@ module Parse = struct
         if cp >= 0xd800 && cp <= 0xdbff then
           `UTF16(cp, `S)
         else begin
-          Buffer.add_char buf (Char.unsafe_chr (0b11100000 lor ((cp lsr 12) land 0b00001111)));
-          Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor ((cp lsr  6) land 0b00111111)));
-          Buffer.add_char buf (Char.unsafe_chr (0b10000000 lor (cp          land 0b00111111)));
+          utf8_of_code buf cp ;
           `Unescaped
         end
     | cs -> `UTF8 (d::cs)

--- a/lib/jsonaf.ml
+++ b/lib/jsonaf.ml
@@ -101,10 +101,10 @@ module With_number = struct
   let parse = Parser.parse
 
   let of_string number_of_string string =
-    Angstrom.parse_string (parse number_of_string) string
+    Angstrom.parse_string ~consume:Angstrom.Consume.All (parse number_of_string) string
 
   let of_bigstring number_of_string bigstring =
-    Angstrom.parse_bigstring (parse number_of_string) bigstring
+    Angstrom.parse_bigstring ~consume:Angstrom.Consume.All (parse number_of_string) bigstring
 
   let rec serialize serialize_number t faraday =
     match t with


### PR DESCRIPTION
Hi.

I debugged and "fixed" (by copying/pasting [code from Yojson](https://github.com/ocaml-community/yojson/blob/0031b1bb9cf15aa54493a39c495a5c78bd2a2c43/lib/common.ml#L16)) the unicode code point decoding.

Prior to this PR, this is the behavior of jsonaf:
```ocaml
match Jsonaf.of_string {| { "foo": "\u00E9" } |} with
| Ok (`Object ["foo", `String s]) -> s
| _ -> assert false ;;
- : string = "à©"
```

```ocaml
match Jsonaf.of_string {| { "foo": "\u00E9" } |} with
| Ok (`Object ["foo", `String s]) -> s
| _ -> assert false ;;
- : string = "é"
```

`\u00E9` is `é` (cf: http://www.fileformat.info/info/unicode/char/e9/index.htm)

---

Also, I upgrade the build to use recent versions of `dune`. I am not sure about what is done in opam file, but `dune upgrade` is responsible for this.