### PR TITLE
Upgrade to angstrom >= 14

### DIFF
--- a/jsonaf.opam
+++ b/jsonaf.opam
@@ -15,7 +15,7 @@ build-test: [
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "alcotest" {test}
-  "angstrom" {>= "0.7.0"}
+  "angstrom" {>= "0.14.0"}
   "faraday"  {>= "0.5.0"}
   "result"
 ]

--- a/lib/jsonaf.ml
+++ b/lib/jsonaf.ml
@@ -101,10 +101,10 @@ module With_number = struct
   let parse = Parser.parse
 
   let of_string number_of_string string =
-    Angstrom.parse_string (parse number_of_string) string
+    Angstrom.parse_string ~consume:Prefix (parse number_of_string) string
 
   let of_bigstring number_of_string bigstring =
-    Angstrom.parse_bigstring (parse number_of_string) bigstring
+    Angstrom.parse_bigstring ~consume:Prefix (parse number_of_string) bigstring
 
   let rec serialize serialize_number t faraday =
     match t with


### PR DESCRIPTION
Use the `Angstrom.parse_(big)?string` interface as of angstrom 0.14.0.

I went with `~consume:Prefix` since I believe that is the existing behavior.